### PR TITLE
Closes issue #6, overlapping data blocks in mcd file.

### DIFF
--- a/readimc/mcd_parser.py
+++ b/readimc/mcd_parser.py
@@ -2,7 +2,7 @@ import re
 from typing import Dict, List, Optional, Tuple
 from warnings import warn
 from xml.etree import ElementTree as ET
-
+import itertools
 from .data import Acquisition, Panorama, Slide
 
 
@@ -121,6 +121,20 @@ class MCDParser:
                     slide.acquisitions.append(acquisition)
                     if panorama is not None:
                         panorama.acquisitions.append(acquisition)
+                        
+        #Check for possible overlap of memory blocks between qcquisitions:
+        acqDict={}
+        for acq in slide.acquisitions:
+            acqDict[slide.acquisitions.index(acq)]= [acq.metadata['DataStartOffset'], acq.metadata['DataEndOffset']]    
+        # Only do minimum number of comparisons between the elemnts.
+        for a, b in itertools.combinations(acqDict.items(), 2):
+            if (b[1][0] <= a[1][0] and b[1][1] > a[1][0]) or (b[1][0] < a[1][1] and b[1][1] >= a[1][1]):
+                warn(
+                    "The mcd file appears to be curropted. There are memory blocks that map to both acquisitions "  +str(a[0]) + 
+                    " and "+ str(b[0]) + ". In an uncurropted file a given memory block should map to only one acquisition"
+                )                        
+                        
+                        
         slide.panoramas.sort(key=lambda panorama: panorama.id)
         slide.acquisitions.sort(key=lambda acquisition: acquisition.id)
         return slide


### PR DESCRIPTION
This has been tested using a xml file which was manually changed to contain an acquisition overlap (xmltree) and then calling parse_slides() from an instance of MCDParser: `result=MCDParser(xmltree).parse_slides()`.