### PR TITLE
Lenient extraction of corrupted imaging data

### DIFF
--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -125,7 +125,7 @@ class MCDFile(IMCFile):
         if data_size % bytes_per_pixel != 0:
             data_size += 1
         if data_size % bytes_per_pixel != 0:
-            if strict == True:
+            if strict:
                 raise IOError(
                     f"MCD file '{self.path.name}' corrupted: "
                     "invalid acquisition image data size"

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -147,8 +147,8 @@ class MCDFile(IMCFile):
         xs = data[:, 0].astype(int)
         ys = data[:, 1].astype(int)
         try:
-            width = int(acquisition.metadata["MaxX"]) + 1
-            height = int(acquisition.metadata["MaxY"]) + 1
+            width = int(acquisition.metadata["MaxX"])
+            height = int(acquisition.metadata["MaxY"])
             if width <= np.amax(xs) or height <= np.amax(ys):
                 raise ValueError(
                     "data shape is incompatible with acquisition image dimensions"

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -153,7 +153,7 @@ class MCDFile(IMCFile):
                     "inconsistent acquisition image data size"
                 )
 
-        else:  # strict == False
+        else:
             width = int(acquisition.metadata["MaxX"])
             height = int(acquisition.metadata["MaxY"])
             if width * height != num_pixels:

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -145,7 +145,7 @@ class MCDFile(IMCFile):
             shape=(num_pixels, num_channels + 3),
         )
 
-        if strict == True:  # default behavior
+        if strict:
             width, height = np.amax(data[:, :2], axis=0).astype(int) + 1
             if width * height != data.shape[0]:
                 raise IOError(

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -90,7 +90,9 @@ class MCDFile(IMCFile):
             self._fh.close()
             self._fh = None
 
-    def read_acquisition(self, acquisition: Optional[Acquisition] = None, strict = True) -> np.ndarray:
+    def read_acquisition(
+        self, acquisition: Optional[Acquisition] = None, strict=True
+    ) -> np.ndarray:
         """Reads IMC acquisition data as numpy array.
 
         :param acquisition: the acquisition to read
@@ -120,20 +122,20 @@ class MCDFile(IMCFile):
         num_channels = acquisition.num_channels
         data_size = data_end_offset - data_start_offset
         bytes_per_pixel = (num_channels + 3) * value_bytes
-        
-        if data_size % bytes_per_pixel != 0:            
+
+        if data_size % bytes_per_pixel != 0:
             data_size += 1
-        
+
         if data_size % bytes_per_pixel != 0:
             if strict == True:
                 raise IOError(
-                f"MCD file '{self.path.name}' corrupted: "
-                "invalid acquisition image data size"
+                    f"MCD file '{self.path.name}' corrupted: "
+                    "invalid acquisition image data size"
                 )
-            else: # strict == False, print error and continue
+            else:  # strict == False, print error and continue
                 print(
-                f"MCD file '{self.path.name}' corrupted: "
-                "invalid acquisition image data size"
+                    f"MCD file '{self.path.name}' corrupted: "
+                    "invalid acquisition image data size"
                 )
         num_pixels = data_size // bytes_per_pixel
         self._fh.seek(0)
@@ -144,27 +146,27 @@ class MCDFile(IMCFile):
             offset=data_start_offset,
             shape=(num_pixels, num_channels + 3),
         )
-        
-        if strict == True: # default behavior
+
+        if strict == True:  # default behavior
             width, height = np.amax(data[:, :2], axis=0).astype(int) + 1
             if width * height != data.shape[0]:
                 raise IOError(
                     f"MCD file '{self.path.name}' corrupted: "
                     "inconsistent acquisition image data size"
-                    )
-            
-        else: #strict == False
+                )
+
+        else:  # strict == False
             width = int(acquisition.metadata["MaxX"])
             height = int(acquisition.metadata["MaxY"])
             if width * height != num_pixels:
                 print(
                     f"MCD file '{self.path.name}' corrupted: "
                     "inconsistent acquisition image data size"
-                    )
-            append_pixel = (width * height)-num_pixels
+                )
+            append_pixel = (width * height) - num_pixels
             append_data = np.zeros((append_pixel, num_channels), dtype=np.float32)
             np.append(data, append_data)
-        
+
         img = np.zeros((height, width, num_channels), dtype=np.float32)
         img[data[:, 1].astype(int), data[:, 0].astype(int), :] = data[:, 3:]
         return np.moveaxis(img, -1, 0)

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -131,7 +131,7 @@ class MCDFile(IMCFile):
                     "invalid acquisition image data size"
                 )
             else:
-                print(
+                warn(
                     f"MCD file '{self.path.name}' corrupted: "
                     "invalid acquisition image data size"
                 )

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -122,7 +122,6 @@ class MCDFile(IMCFile):
         num_channels = acquisition.num_channels
         data_size = data_end_offset - data_start_offset
         bytes_per_pixel = (num_channels + 3) * value_bytes
-
         if data_size % bytes_per_pixel != 0:
             data_size += 1
 

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -124,7 +124,6 @@ class MCDFile(IMCFile):
         bytes_per_pixel = (num_channels + 3) * value_bytes
         if data_size % bytes_per_pixel != 0:
             data_size += 1
-
         if data_size % bytes_per_pixel != 0:
             if strict == True:
                 raise IOError(

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -96,6 +96,7 @@ class MCDFile(IMCFile):
         """Reads IMC acquisition data as numpy array.
 
         :param acquisition: the acquisition to read
+        :param strict: set this parameter to False to try to recover corrupted data
         :return: the acquisition data as 32-bit floating point array,
             shape: (c, y, x)
         """
@@ -130,11 +131,10 @@ class MCDFile(IMCFile):
                     f"MCD file '{self.path.name}' corrupted: "
                     "invalid acquisition image data size"
                 )
-            else:
-                warn(
-                    f"MCD file '{self.path.name}' corrupted: "
-                    "invalid acquisition image data size"
-                )
+            warn(
+                f"MCD file '{self.path.name}' corrupted: "
+                "invalid acquisition image data size"
+            )
         num_pixels = data_size // bytes_per_pixel
         self._fh.seek(0)
         data = np.memmap(
@@ -144,7 +144,6 @@ class MCDFile(IMCFile):
             offset=data_start_offset,
             shape=(num_pixels, num_channels + 3),
         )
-
         if strict:
             width, height = np.amax(data[:, :2], axis=0).astype(int) + 1
             if width * height != data.shape[0]:
@@ -164,7 +163,6 @@ class MCDFile(IMCFile):
             append_pixel = (width * height) - num_pixels
             append_data = np.zeros((append_pixel, num_channels), dtype=np.float32)
             data = np.append(data, append_data)
-
         img = np.zeros((height, width, num_channels), dtype=np.float32)
         img[data[:, 1].astype(int), data[:, 0].astype(int), :] = data[:, 3:]
         return np.moveaxis(img, -1, 0)

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -91,7 +91,7 @@ class MCDFile(IMCFile):
             self._fh = None
 
     def read_acquisition(
-        self, acquisition: Optional[Acquisition] = None, strict=True
+        self, acquisition: Optional[Acquisition] = None, strict: bool = True
     ) -> np.ndarray:
         """Reads IMC acquisition data as numpy array.
 

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -163,7 +163,7 @@ class MCDFile(IMCFile):
                 )
             append_pixel = (width * height) - num_pixels
             append_data = np.zeros((append_pixel, num_channels), dtype=np.float32)
-            np.append(data, append_data)
+            data = np.append(data, append_data)
 
         img = np.zeros((height, width, num_channels), dtype=np.float32)
         img[data[:, 1].astype(int), data[:, 0].astype(int), :] = data[:, 3:]

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -130,7 +130,7 @@ class MCDFile(IMCFile):
                     f"MCD file '{self.path.name}' corrupted: "
                     "invalid acquisition image data size"
                 )
-            else:  # strict == False, print error and continue
+            else:
                 print(
                     f"MCD file '{self.path.name}' corrupted: "
                     "invalid acquisition image data size"


### PR DESCRIPTION
I work for StandardBio, and it is a known thing that the last scan sometimes is not complete.

This generates an incomplete numpy array for that acquisition.

The default "read_acquisition" is called with "strict=True", but when called with "strict=False", it will populate the missing data in the last scan with "zeros" and allow the retrieval of the acquisition.