### PR TITLE
Lenient extraction of corrupted imaging data TXT files

### DIFF
--- a/readimc/txt_file.py
+++ b/readimc/txt_file.py
@@ -94,7 +94,9 @@ class TXTFile(IMCFile, AcquisitionBase):
             self._fh.close()
             self._fh = None
 
-    def read_acquisition(self, acquisition: Optional[Acquisition] = None, strict: bool = True) -> np.ndarray:
+    def read_acquisition(
+        self, acquisition: Optional[Acquisition] = None, strict: bool = True
+    ) -> np.ndarray:
         """Reads IMC acquisition data as numpy array.
 
         :param acquisition: the acquisition to read (for compatibility with ``IMCFile``

--- a/readimc/txt_file.py
+++ b/readimc/txt_file.py
@@ -93,11 +93,12 @@ class TXTFile(IMCFile, AcquisitionBase):
             self._fh.close()
             self._fh = None
 
-    def read_acquisition(self, acquisition: Optional[Acquisition] = None) -> np.ndarray:
+    def read_acquisition(self, acquisition: Optional[Acquisition] = None, strict: bool = True) -> np.ndarray:
         """Reads IMC acquisition data as numpy array.
 
         :param acquisition: the acquisition to read (for compatibility with ``IMCFile``
             and ``MCDFile``; unused)
+        :param strict: set this parameter to False to try to recover corrupted data
         :return: the acquisition data as 32-bit floating point array,
             shape: (c, y, x)
         """
@@ -121,7 +122,12 @@ class TXTFile(IMCFile, AcquisitionBase):
             )
         width, height = df[["X", "Y"]].add(1).max(axis=0).astype(int)
         if width * height != len(df.index):
-            raise IOError(
+            if strict:
+                raise IOError(
+                    f"TXT file '{self.path.name}' corrupted: "
+                    "inconsistent acquisition image data size"
+                )
+            warn(
                 f"TXT file '{self.path.name}' corrupted: "
                 "inconsistent acquisition image data size"
             )

--- a/readimc/txt_file.py
+++ b/readimc/txt_file.py
@@ -1,6 +1,7 @@
 import re
 from os import PathLike
 from typing import List, Optional, Sequence, TextIO, Tuple, Union
+from warnings import warn
 
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Following https://github.com/BodenmillerGroup/readimc/pull/19.

I encountered the same issue when reading also acquisition TXT files. Looking at the changed code in the develop branch I see the strict option was only enabled when reading MCD file acquisition.

I changed the code in read_acquisition in the [txt_file.py](https://github.com/BodenmillerGroup/readimc/blob/develop/readimc/txt_file.py) to add the strict option also there (a very small change).

Running all tests I see that some tests fail but not regarding txt_file.py changes I assume that this is related to different changes done on the develop branch.

Hope this is the correct way to contribute and let me know if I can help with anything else.