### PR TITLE
Update mcd_file.py

### DIFF
--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -174,7 +174,9 @@ class MCDFile(IMCFile):
         img[:, ys, xs] = np.transpose(data[:, 3:])
         return img
 
-    def read_slide(self, slide: Slide, raw: bool = False) -> Union[np.ndarray, bytes, None]:
+    def read_slide(
+        self, slide: Slide, raw: bool = False
+    ) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a slide image as numpy array using the ``imageio``
         package.
 
@@ -214,7 +216,9 @@ class MCDFile(IMCFile):
                 f"cannot read image for slide {slide.id}"
             ) from e
 
-    def read_panorama(self, panorama: Panorama, raw: bool = False) -> Union[np.ndarray, bytes, None]:
+    def read_panorama(
+        self, panorama: Panorama, raw: bool = False
+    ) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a panorama image as numpy array using the
         ``imageio`` package.
 
@@ -248,8 +252,7 @@ class MCDFile(IMCFile):
             ) from e
 
     def read_before_ablation_image(
-        self, acquisition: Acquisition,
-        raw: bool = False
+        self, acquisition: Acquisition, raw: bool = False
     ) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a before-ablation image as numpy array using the
         ``imageio`` package.
@@ -361,15 +364,17 @@ class MCDFile(IMCFile):
             data = mm.read(end_index + len(end_sub_encoded) - start_index)
         return data.decode(encoding=encoding)
 
-    def _read_image(self, data_offset: int, data_size: int, raw: bool = False) -> Union[np.ndarray, bytes]:
+    def _read_image(
+        self, data_offset: int, data_size: int, raw: bool = False
+    ) -> Union[np.ndarray, bytes]:
         if self._fh is None:
             raise IOError(f"MCD file '{self.path.name}' has not been opened")
         self._fh.seek(data_offset)
         data = self._fh.read(data_size)
         if raw:
-          return data
+            return data
         else:
-          return imread(data)
+            return imread(data)
 
     def __repr__(self) -> str:
         return str(self._path)

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -174,7 +174,7 @@ class MCDFile(IMCFile):
         img[:, ys, xs] = np.transpose(data[:, 3:])
         return img
 
-    def read_slide(self, slide: Slide) -> Optional[np.ndarray]:
+    def read_slide(self, slide: Slide, raw: bool = False) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a slide image as numpy array using the ``imageio``
         package.
 
@@ -206,7 +206,7 @@ class MCDFile(IMCFile):
             )
         try:
             return self._read_image(
-                data_start_offset, data_end_offset - data_start_offset
+                data_start_offset, data_end_offset - data_start_offset, raw
             )
         except Exception as e:
             raise IOError(
@@ -214,7 +214,7 @@ class MCDFile(IMCFile):
                 f"cannot read image for slide {slide.id}"
             ) from e
 
-    def read_panorama(self, panorama: Panorama) -> np.ndarray:
+    def read_panorama(self, panorama: Panorama, raw: bool = False) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a panorama image as numpy array using the
         ``imageio`` package.
 
@@ -229,6 +229,8 @@ class MCDFile(IMCFile):
                 f"MCD file '{self.path.name}' corrupted: "
                 f"cannot locate image data for panorama {panorama.id}"
             ) from e
+        if data_start_offset == data_end_offset == 0:
+            return None
         data_start_offset += 161
         if data_start_offset >= data_end_offset:
             raise IOError(
@@ -237,7 +239,7 @@ class MCDFile(IMCFile):
             )
         try:
             return self._read_image(
-                data_start_offset, data_end_offset - data_start_offset
+                data_start_offset, data_end_offset - data_start_offset, raw
             )
         except Exception as e:
             raise IOError(
@@ -246,8 +248,9 @@ class MCDFile(IMCFile):
             ) from e
 
     def read_before_ablation_image(
-        self, acquisition: Acquisition
-    ) -> Optional[np.ndarray]:
+        self, acquisition: Acquisition,
+        raw: bool = False
+    ) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a before-ablation image as numpy array using the
         ``imageio`` package.
 
@@ -278,7 +281,7 @@ class MCDFile(IMCFile):
             )
         try:
             return self._read_image(
-                data_start_offset, data_end_offset - data_start_offset
+                data_start_offset, data_end_offset - data_start_offset, raw
             )
         except Exception as e:
             raise IOError(
@@ -288,8 +291,8 @@ class MCDFile(IMCFile):
             ) from e
 
     def read_after_ablation_image(
-        self, acquisition: Acquisition
-    ) -> Optional[np.ndarray]:
+        self, acquisition: Acquisition, raw: bool = False
+    ) -> Union[np.ndarray, bytes, None]:
         """Reads and decodes a after-ablation image as numpy array using the
         ``imageio`` package.
 
@@ -320,7 +323,7 @@ class MCDFile(IMCFile):
             )
         try:
             return self._read_image(
-                data_start_offset, data_end_offset - data_start_offset
+                data_start_offset, data_end_offset - data_start_offset, raw
             )
         except Exception as e:
             raise IOError(
@@ -358,12 +361,15 @@ class MCDFile(IMCFile):
             data = mm.read(end_index + len(end_sub_encoded) - start_index)
         return data.decode(encoding=encoding)
 
-    def _read_image(self, data_offset: int, data_size: int) -> np.ndarray:
+    def _read_image(self, data_offset: int, data_size: int, raw: bool = False) -> Union[np.ndarray, bytes]:
         if self._fh is None:
             raise IOError(f"MCD file '{self.path.name}' has not been opened")
         self._fh.seek(data_offset)
         data = self._fh.read(data_size)
-        return imread(data)
+        if raw:
+          return data
+        else:
+          return imread(data)
 
     def __repr__(self) -> str:
         return str(self._path)


### PR DESCRIPTION
The before and after ablation images are PNGs, and usually one will not want to do any processing on this data.

The current functionality retrieves this data as a numpy array, due to which the properties attached to the png file are lost (e.g. timestamp when it was created).

The code has been modified to maintain the normal behavior, but if the "raw" boolean flag is specified during the request of these files, then the raw png data is returned (as opposed to the numpy array).

One can easily save this data to a png file, and retain all the metadata associated with the png file.