### PR TITLE
Mmap acquisition vi

### DIFF
--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -104,10 +104,12 @@ class MCDFile(IMCFile):
         memory-mapping and/or subsetting.
 
         :param acquisition: The acquisition to read.
-        :param strict: If True, raises errors for inconsistencies; otherwise, warns and recovers.
+        :param strict: If True, raises errors for inconsistencies; otherwise, 
+        warns and recovers.
         :param channels: List of channel indices to load (zero-based).
         :param region: Tuple (x_min, y_min, x_max, y_max) to subset the image region.
-        :param create_temp_file: Directory to store a temporary file (if provided, memory-mapping is used).
+        :param create_temp_file: Directory to store a temporary file (if provided, 
+        memory-mapping is used).
         :return: The acquisition data as a 32-bit float array, shape (c, y, x).
         """
         if acquisition is None:
@@ -150,7 +152,8 @@ class MCDFile(IMCFile):
             warn(f"MCD file '{self.path.name}' contains empty acquisition image data")
         if data_end_offset > file_size:
             raise IOError(
-                f"MCD file corrupted: data_end_offset ({data_end_offset}) exceeds file size ({file_size})."
+                f"MCD file corrupted: data_end_offset ({data_end_offset}) "
+                f"exceeds file size ({file_size})."
             )
 
         # Compute bytes per pixel and validate data size
@@ -169,7 +172,8 @@ class MCDFile(IMCFile):
         if channels is not None:
             if not all(0 <= c < num_channels for c in channels):
                 raise ValueError(
-                    f"Invalid channel indices: {channels}. Must be between 0 and {num_channels - 1}."
+                    f"Invalid channel indices: {channels}." 
+                    f"Must be between 0 and {num_channels - 1}."
                 )
 
         # Calculate number of pixels based on the data size
@@ -211,7 +215,8 @@ class MCDFile(IMCFile):
         if xs.size == 0 or ys.size == 0:
             return np.zeros((num_selected_channels, height, width), dtype=np.float32)
 
-        # Now we either use a temporary file or in-memory NumPy array for storing the image data
+        # Now we either use a temporary file or in-memory NumPy array 
+        # for storing the image data
         if create_temp_file:
             create_temp_file.mkdir(parents=True, exist_ok=True)
             temp_file = tempfile.NamedTemporaryFile(
@@ -237,123 +242,6 @@ class MCDFile(IMCFile):
 
         return img
 
-    '''def read_acquisition(
-        self,
-        acquisition: Optional[Acquisition] = None,
-        strict: bool = True,
-        channels: Optional[List[int]] = None,
-        region: Optional[Tuple[int, int, int, int]] = None,
-        create_temp_file: Optional[PathLike] = None,
-    ) -> np.ndarray:
-        """Reads IMC acquisition data as a numpy array with optional
-          memory-mapping and/or subsetting.
-
-        :param acquisition: The acquisition to read.
-        :param strict: If True, raises errors for inconsistencies;
-          otherwise, warns and recovers.
-        :param channels: List of channel indices to load (zero-based).
-        :param region: Tuple (x_min, y_min, x_max, y_max) to subset the image region.
-        :param create_temp_file: Directory to store a temporary file
-          (if provided, memory-mapping is used).
-        :return: The acquisition data as a 32-bit float array, shape (c, y, x).
-        """
-        if acquisition is None:
-            raise ValueError("acquisition must be specified")
-        if self._fh is None:
-            raise IOError(f"MCD file '{self.path.name}' has not been opened")
-        if channels is not None and not all(isinstance(c, int) for c in channels):
-            raise ValueError("channels must be a list of integers")
-        if region is not None and not all(isinstance(c, int) for c in region):
-            raise ValueError("region must be a tuple of integers")
-        if region is not None:
-            if region[0] >= region[2] or region[1] >= region[3]:
-                raise ValueError("region must be (x_min, y_min, x_max, y_max)")
-        if create_temp_file:
-            if not isinstance(create_temp_file, (str, Path)):
-                raise ValueError("create_temp_file must be a string or Path object.")
-            create_temp_file = Path(create_temp_file)
-            if not create_temp_file.exists() or not access(str(create_temp_file), W_OK):
-                raise PermissionError(f"The path {create_temp_file} is not writable.")
-        try:
-            data_start_offset = int(acquisition.metadata["DataStartOffset"])
-            data_end_offset = int(acquisition.metadata["DataEndOffset"])
-            value_bytes = int(acquisition.metadata["ValueBytes"])
-            width = int(acquisition.metadata["MaxX"])
-            height = int(acquisition.metadata["MaxY"])
-        except (KeyError, ValueError) as e:
-            raise IOError(
-                f"MCD file '{self.path.name}' corrupted: missing metadata"
-            ) from e
-        file_size = path.getsize(self.path)
-        if data_start_offset > data_end_offset or value_bytes <= 0:
-            raise IOError("MCD file corrupted: invalid data offsets or byte size")
-        if data_start_offset == data_end_offset:
-            warn(f"MCD file '{self.path.name}' contains empty acquisition image data")
-        if data_end_offset > file_size:
-            raise IOError(f"MCD file corrupted: data_end_offset ({data_end_offset}) exceeds file size ({file_size}).")
-        num_channels = acquisition.num_channels
-        bytes_per_pixel = (num_channels + 3) * value_bytes
-        data_size = data_end_offset - data_start_offset
-        if data_size % bytes_per_pixel != 0:
-            if strict:
-                raise IOError(
-                    f"MCD file '{self.path.name}' corrupted: invalid data size"
-                )
-            warn(f"MCD file '{self.path.name}' corrupted: adjusting data size")
-            data_size += 1
-        if channels is not None:
-            if not all(0 <= c < num_channels for c in channels):
-                raise ValueError(f"Invalid channel indices: {channels}. Must be between 0 and {num_channels - 1}.")
-        num_pixels = data_size // bytes_per_pixel
-        self._fh.seek(0)
-        data = np.memmap(
-            self._fh,
-            dtype=np.float32,
-            mode="r",
-            offset=data_start_offset,
-            shape=(num_pixels, num_channels + 3),
-        )
-        xs = data[:, 0].copy().astype(int)
-        ys = data[:, 1].copy().astype(int)
-
-        if region is not None:
-            if region[2] > width or region[3] > height:
-                raise ValueError("Region is larger than the image")
-            x_min, y_min, x_max, y_max = region
-            mask = (xs >= x_min) & (xs < x_max) & (ys >= y_min) & (ys < y_max)
-            xs = xs[mask] - x_min
-            ys = ys[mask] - y_min
-            data = data[mask]
-            width = x_max - x_min
-            height = y_max - y_min
-        if channels is not None:
-            num_selected_channels = len(channels)
-        else:
-            num_selected_channels = num_channels
-        if xs.size == 0 or ys.size == 0:
-            return np.zeros((num_selected_channels, height, width), dtype=np.float32)
-        if create_temp_file:
-            if isinstance(create_temp_file, (str, PathLike)):
-                create_temp_file = Path(create_temp_file)
-            create_temp_file.mkdir(parents=True, exist_ok=True)
-            temp_file = tempfile.NamedTemporaryFile(
-                delete=False, dir=str(create_temp_file)
-            )
-            img = np.memmap(
-                temp_file.name,
-                dtype=np.float32,
-                mode="r",
-                shape=(num_selected_channels, height, width),
-            )
-            warn(f"Temporary file created: {temp_file.name}")
-        else:
-            img = np.zeros((num_selected_channels, height, width), dtype=np.float32)
-        for i, c in enumerate(
-            channels if channels is not None else range(num_channels)
-        ):
-            img[i, ys, xs] = data[:, c + 3]
-        return img
-'''
 
     def read_slide(self, slide: Slide) -> Optional[np.ndarray]:
         """Reads and decodes a slide image as numpy array using the ``imageio``

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -116,8 +116,6 @@ class MCDFile(IMCFile):
             raise ValueError("acquisition must be specified")
         if self._fh is None:
             raise IOError(f"MCD file '{self.path.name}' has not been opened")
-        #if channels is not None and not all(isinstance(c, int) for c in channels):
-            #raise ValueError("channels must be a list of integers")
         if region is not None and not all(isinstance(c, int) for c in region):
             raise ValueError("region must be a tuple of integers")
         if region is not None:

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -164,8 +164,6 @@ class MCDFile(IMCFile):
         )
         xs = data[:, 0].copy().astype(int)
         ys = data[:, 1].copy().astype(int)
-        if width <= np.amax(xs) or height <= np.amax(ys):
-            raise ValueError("Data shape is incompatible with acquisition dimensions")
         if region is not None:
             x_min, y_min, x_max, y_max = region
             mask = (xs >= x_min) & (xs < x_max) & (ys >= y_min) & (ys < y_max)
@@ -178,7 +176,11 @@ class MCDFile(IMCFile):
             num_selected_channels = len(channels)
         else:
             num_selected_channels = num_channels
+        if xs.size == 0 or ys.size == 0:
+            return np.zeros((num_selected_channels, height, width), dtype=np.float32)
         if create_temp_file:
+            if isinstance(create_temp_file, (str, PathLike)):
+                create_temp_file = Path(create_temp_file)
             create_temp_file.mkdir(parents=True, exist_ok=True)
             temp_file = tempfile.NamedTemporaryFile(
                 delete=False, dir=str(create_temp_file)

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -170,7 +170,9 @@ class MCDFile(IMCFile):
                 f"MCD file '{self.path.name}' corrupted: "
                 "inconsistent acquisition image data size"
             )
-        img = np.zeros((num_channels, height, width), dtype=np.float32)
+        img = np.memmap(
+            'temp_mmap.dat', dtype=np.float32, mode='w+', shape=(num_channels, height, width)
+        )
         img[:, ys, xs] = np.transpose(data[:, 3:])
         return img
 

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -116,8 +116,8 @@ class MCDFile(IMCFile):
             raise ValueError("acquisition must be specified")
         if self._fh is None:
             raise IOError(f"MCD file '{self.path.name}' has not been opened")
-        if channels is not None and not all(isinstance(c, int) for c in channels):
-            raise ValueError("channels must be a list of integers")
+        #if channels is not None and not all(isinstance(c, int) for c in channels):
+            #raise ValueError("channels must be a list of integers")
         if region is not None and not all(isinstance(c, int) for c in region):
             raise ValueError("region must be a tuple of integers")
         if region is not None:

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -98,7 +98,7 @@ class MCDFile(IMCFile):
         strict: bool = True,
         channels: Optional[List[int]] = None,
         region: Optional[Tuple[int, int, int, int]] = None,
-        create_temp_file: Optional[PathLike] = None,
+        create_temp_file: Optional[Path] = None,
     ) -> np.ndarray:
         """Reads IMC acquisition data as a numpy array with optional
         memory-mapping and/or subsetting.

--- a/readimc/mcd_file.py
+++ b/readimc/mcd_file.py
@@ -101,7 +101,7 @@ class MCDFile(IMCFile):
         region: Optional[Tuple[int, int, int, int]] = None,
         create_temp_file: Optional[PathLike] = None,
         ) -> np.ndarray:
-        """Reads IMC acquisition data as a numpy array with optional subsetting.
+        """Reads IMC acquisition data as a numpy array with optional memory-mapping and/or subsetting.
 
         :param acquisition: The acquisition to read.
         :param strict: If True, raises errors for inconsistencies; otherwise, warns and recovers.

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -146,14 +146,14 @@ class TestMCDFile:
             )
 
         # 7. Test for ValueError when an invalid region tuple is provided
-        with pytest.raises(ValueError, match="region must be a tuple of integers"):
-            imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition, region=(0, 0, 10, "invalid")
-            )  # Type mismatch
+        #with pytest.raises(ValueError, match="region must be a tuple of integers"):
+            #imc_test_data_mcd_file.read_acquisition(
+                #acquisition=acquisition, region=(0, 0, 10, "invalid")
+            #)  # Type mismatch
 
         # 8. Test for ValueError when region bounds are out of order
         invalid_region_2: Tuple[int, int, int, int] = (50, 50, 10, 10)  # Invalid region
-        with pytest.raises(ValueError, match="region must be \(x_min, y_min, x_max, y_max\)"):
+        with pytest.raises(ValueError, match="region must be \\(x_min, y_min, x_max, y_max\\)"):
             imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=invalid_region_2)
 
         # 10. Test for handling empty acquisition data with a warning

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -135,16 +135,6 @@ class TestMCDFile:
                 acquisition=acquisition, region=invalid_region_1
             )
 
-<<<<<<< HEAD
-=======
-        # Test with invalid channel names
-        # invalid_channels: Tuple[int, str, float] = [1, '2', 3.0]
-        # with pytest.raises(ValueError, match="channels must be a list of integers"):
-        # imc_test_data_mcd_file.read_acquisition(
-        # acquisition=acquisition, channels=invalid_channels
-        # )
-
->>>>>>> 22acc4ede005ff7473ecf1f5cfb9f165276ecbc2
         # Test for ValueError when no acquisition is provided
         with pytest.raises(ValueError, match="acquisition must be specified"):
             imc_test_data_mcd_file.read_acquisition(acquisition=None)

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -132,13 +132,8 @@ class TestMCDFile:
     def test_read_acquisition_empty_data(self, imc_test_data_mcd_file: MCDFile):
         slide = imc_test_data_mcd_file.slides[0]
         acquisition = next(a for a in slide.acquisitions if a.id == 1)
-<<<<<<< HEAD
         acquisition.metadata["DataStartOffset"] = "100"
-        acquisition.metadata["DataEndOffset"] = "100" 
-=======
-        acquisition.metadata["DataStartOffset"] = 100
-        acquisition.metadata["DataEndOffset"] = 100
->>>>>>> 027aab62f595f7177cc3882ae9a4f35a31898aa6
+        acquisition.metadata["DataEndOffset"] = "100"
         with pytest.warns(UserWarning, match="contains empty acquisition image data"):
             img = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
             assert img.shape == (5, 60, 60)

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -135,6 +135,12 @@ class TestMCDFile:
                 acquisition=acquisition, region=invalid_region_1
             )
 
+        # Test with invalid channel names
+        with pytest.raises(ValueError, match="channels must be a list of integers"):
+            imc_test_data_mcd_file.read_acquisition(
+                acquisition=acquisition, channels=[1, '2', 3.0]
+            )
+
         # Test for ValueError when no acquisition is provided
         with pytest.raises(ValueError, match="acquisition must be specified"):
             imc_test_data_mcd_file.read_acquisition(acquisition=None)

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -102,7 +102,7 @@ class TestMCDFile:
         )
 
     def test_read_acquisition(self, imc_test_data_mcd_file: MCDFile) -> None:
-        # 1. Test the standard read without channels or region
+        # Test the standard read without channels or region
         slide = imc_test_data_mcd_file.slides[0]
         acquisition = next(a for a in slide.acquisitions if a.id == 1)
 
@@ -112,7 +112,7 @@ class TestMCDFile:
         assert img_full.dtype == np.float32
         assert img_full.shape == (5, 60, 60)
 
-        # 2. Test with specified channels
+        # Test with specified channels
         channels: List[int] = [0, 2]
         img_channels: np.ndarray = imc_test_data_mcd_file.read_acquisition(
             acquisition=acquisition, channels=channels
@@ -120,7 +120,7 @@ class TestMCDFile:
         assert img_channels.dtype == np.float32
         assert img_channels.shape == (2, 60, 60)
 
-        # 3. Test with specified region
+        # Test with specified region
         region: Tuple[int, int, int, int] = (10, 10, 50, 50)
         img_region: np.ndarray = imc_test_data_mcd_file.read_acquisition(
             acquisition=acquisition, region=region
@@ -128,35 +128,31 @@ class TestMCDFile:
         assert img_region.dtype == np.float32
         assert img_region.shape == (5, 40, 40)
 
-        # 4. Test with invalid region
+        # Test with invalid region
         invalid_region_1: Tuple[int, int, int, int] = (0, 0, 1000, 1000)
         with pytest.raises(ValueError, match="Region is larger than the image"):
             imc_test_data_mcd_file.read_acquisition(
                 acquisition=acquisition, region=invalid_region_1
             )
 
-        # 5. Test for ValueError when no acquisition is provided
+        # Test for ValueError when no acquisition is provided
         with pytest.raises(ValueError, match="acquisition must be specified"):
             imc_test_data_mcd_file.read_acquisition(acquisition=None)
 
-        # 6. Test for ValueError when invalid channel indices are provided
+        # Test for ValueError when invalid channel indices are provided
         with pytest.raises(ValueError, match="Invalid channel indices"):
             imc_test_data_mcd_file.read_acquisition(
                 acquisition=acquisition, channels=[999]  # Out-of-bounds index
             )
 
-        # 7. Test for ValueError when an invalid region tuple is provided
-        #with pytest.raises(ValueError, match="region must be a tuple of integers"):
-            #imc_test_data_mcd_file.read_acquisition(
-                #acquisition=acquisition, region=(0, 0, 10, "invalid")
-            #)  # Type mismatch
-
-        # 8. Test for ValueError when region bounds are out of order
+        # Test for ValueError when region bounds are out of order
         invalid_region_2: Tuple[int, int, int, int] = (50, 50, 10, 10)  # Invalid region
-        with pytest.raises(ValueError, match="region must be \\(x_min, y_min, x_max, y_max\\)"):
-            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=invalid_region_2)
+        with pytest.raises(ValueError, 
+            match="region must be \\(x_min, y_min, x_max, y_max\\)"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, 
+            region=invalid_region_2)
 
-        # 10. Test for handling empty acquisition data with a warning
+        # Test for handling empty acquisition data with a warning
         acquisition.metadata["DataStartOffset"] = "100"
         acquisition.metadata["DataEndOffset"] = "100"
         with pytest.warns(UserWarning, match="contains empty acquisition image data"):
@@ -165,7 +161,7 @@ class TestMCDFile:
             )
             assert img_empty.shape == (5, 60, 60)
 
-        # 12. Test for reading with `strict=False`, allowing recovery from issues
+        # Test for reading with `strict=False`, allowing recovery from issues
         acquisition.metadata["DataStartOffset"] = "100"
         acquisition.metadata["DataEndOffset"] = (
             "105"  # Corrupted but will try to recover
@@ -175,28 +171,11 @@ class TestMCDFile:
         )
         assert img_recover.shape == (5, 60, 60)
 
-        # 13. Test for IOError when invalid data offsets are provided
+        # Test for IOError when invalid data offsets are provided
         acquisition.metadata["DataStartOffset"] = "200"
         acquisition.metadata["DataEndOffset"] = "100"  # Invalid offsets
         with pytest.raises(IOError, match="invalid data offsets or byte size"):
             imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
-
-    """def test_memory_mapping_with_temp_file(self, imc_test_data_mcd_file: MCDFile):
-        slide = imc_test_data_mcd_file.slides[0]
-        acquisition = next(a for a in slide.acquisitions if a.id == 1)
-        # Ensure a writable temp directory
-        temp_dir = Path(tempfile.mkdtemp())  # Create a temporary writable directory
-        try:
-            img_memmap: np.ndarray = imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition, create_temp_file=temp_dir
-            )
-
-            # Assertions
-            assert img_memmap.dtype == np.float32
-            assert img_memmap.shape == (5, 60, 60)
-            assert not img_memmap.flags["WRITEABLE"]  # Memory-mapped arrays are read-only
-        finally:
-            shutil.rmtree(temp_dir)  # Cleanup the temp directory after the test"""
 
     def test_read_acquisition_empty_data(self, imc_test_data_mcd_file: MCDFile):
         slide = imc_test_data_mcd_file.slides[0]

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -136,10 +136,11 @@ class TestMCDFile:
             )
 
         # Test with invalid channel names
-        with pytest.raises(ValueError, match="channels must be a list of integers"):
-            imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition, channels=[1, '2', 3.0]
-            )
+        #invalid_channels: Tuple[int, str, float] = [1, '2', 3.0]
+        #with pytest.raises(ValueError, match="channels must be a list of integers"):
+            #imc_test_data_mcd_file.read_acquisition(
+                #acquisition=acquisition, channels=invalid_channels
+            #)
 
         # Test for ValueError when no acquisition is provided
         with pytest.raises(ValueError, match="acquisition must be specified"):

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -5,6 +5,9 @@ import numpy as np
 import pytest
 import tempfile
 import os
+from unittest.mock import patch
+from warnings import warn
+from os import access, W_OK
 
 from readimc import MCDFile
 
@@ -102,28 +105,61 @@ class TestMCDFile:
             (31080.701956188677, 13389.195237582955),
         )
 
-    def test_read_acquisition(self, imc_test_data_mcd_file: MCDFile):
+    def test_read_acquisition(self, imc_test_data_mcd_file: MCDFile, tmp_path: Path):
         slide = imc_test_data_mcd_file.slides[0]
         acquisition = next(a for a in slide.acquisitions if a.id == 1)
+
+        # Valid case
         img = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
         assert img.dtype == np.float32
         assert img.shape == (5, 60, 60)
 
-        channels = [0, 2]
-        img_channels = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, channels=channels)
-        assert img_channels.dtype == np.float32
-        assert img_channels.shape == (2, 60, 60)
+        # Missing acquisition
+        with pytest.raises(ValueError, match="acquisition must be specified"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=None)
 
-        region = (10, 10, 50, 50)
-        img_region = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=region)
-        assert img_region.dtype == np.float32
-        assert img_region.shape == (5, 40, 40)
+        # File handle `_fh` is None (simulate closed file)
+        imc_test_data_mcd_file._fh = None
+        with pytest.raises(IOError, match="MCD file .* has not been opened"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
 
-        try:
-            invalid_region = (0, 0, 1000, 1000)
-            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=invalid_region)
-        except ValueError as e:
-            assert "Data shape is incompatible with acquisition dimensions" in str(e)
+        # Restore `_fh` for further tests
+        imc_test_data_mcd_file._fh = open(imc_test_data_mcd_file.path, "rb")
+
+        # Invalid `channels` (not all integers)
+        with pytest.raises(ValueError, match="channels must be a list of integers"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, channels=[0, "invalid"])
+
+        # Invalid `region` (not all integers)
+        with pytest.raises(ValueError, match="region must be a tuple of integers"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=(0, 0, "50", 50))
+
+        # Invalid `region` values
+        with pytest.raises(ValueError, match="region must be \\(x_min, y_min, x_max, y_max\\)"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=(10, 10, 5, 50))
+
+        # Invalid `create_temp_file` type
+        with pytest.raises(ValueError, match="create_temp_file must be a string or Path object."):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, create_temp_file=123)
+
+        # Missing metadata keys
+        acquisition.metadata.pop("DataStartOffset", None)
+        with pytest.raises(IOError, match="MCD file .* corrupted: missing metadata"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
+
+        # Restore metadata for next test
+        acquisition.metadata["DataStartOffset"] = "100"
+        acquisition.metadata["DataEndOffset"] = "50"  # Invalid offset order
+
+        with pytest.raises(IOError, match="MCD file corrupted: invalid data offsets or byte size"):
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
+
+        # Restore metadata for empty acquisition test
+        acquisition.metadata["DataEndOffset"] = "100"
+
+        with pytest.warns(UserWarning, match="contains empty acquisition image data"):
+            img = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
+            assert img.shape == (5, 60, 60)
 
     def test_read_slide(self, imc_test_data_mcd_file: MCDFile):
         slide = imc_test_data_mcd_file.slides[0]

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+import tempfile
+import os
 
 from readimc import MCDFile
 
@@ -106,6 +108,22 @@ class TestMCDFile:
         img = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
         assert img.dtype == np.float32
         assert img.shape == (5, 60, 60)
+
+        channels = [0, 2]
+        img_channels = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, channels=channels)
+        assert img_channels.dtype == np.float32
+        assert img_channels.shape == (2, 60, 60)
+
+        region = (10, 10, 50, 50)
+        img_region = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=region)
+        assert img_region.dtype == np.float32
+        assert img_region.shape == (5, 40, 40)
+
+        try:
+            invalid_region = (0, 0, 1000, 1000)
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=invalid_region)
+        except ValueError as e:
+            assert "Data shape is incompatible with acquisition dimensions" in str(e)
 
     def test_read_slide(self, imc_test_data_mcd_file: MCDFile):
         slide = imc_test_data_mcd_file.slides[0]

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -150,7 +150,7 @@ class TestMCDFile:
 
         # 8. Test for ValueError when region bounds are out of order
         invalid_region_2: Tuple[int, int, int, int] = (50, 50, 10, 10)  # Invalid region
-        with pytest.raises(ValueError, match="region must be \\(x_min, y_min, x_max, y_max\\)"):
+        with pytest.raises(ValueError, match="region must be \(x_min, y_min, x_max, y_max\)"):
             imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=invalid_region_2)
 
         # 10. Test for handling empty acquisition data with a warning

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -4,12 +4,9 @@ from typing import List, Tuple
 
 import numpy as np
 import pytest
-<<<<<<< HEAD
 import shutil
 import tempfile
 from typing import List, Tuple, Union
-=======
->>>>>>> 4469fe83c1c82c75f1e112638f69d893d3905ec0
 
 from readimc import MCDFile
 
@@ -113,7 +110,6 @@ class TestMCDFile:
         acquisition = next(a for a in slide.acquisitions if a.id == 1)
         
         img_full: np.ndarray = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
-        assert acquisition != None
         assert img_full.dtype == np.float32
         assert img_full.shape == (5, 60, 60)
 
@@ -143,7 +139,6 @@ class TestMCDFile:
             imc_test_data_mcd_file.read_acquisition(acquisition=None)
 
         # 6. Test for ValueError when invalid channel indices are provided
-<<<<<<< HEAD
         with pytest.raises(ValueError, match="Invalid channel indices"):
             imc_test_data_mcd_file.read_acquisition(
                 acquisition=acquisition, channels=[999]  # Out-of-bounds index
@@ -152,23 +147,6 @@ class TestMCDFile:
         # 7. Test for ValueError when an invalid region tuple is provided
         with pytest.raises(ValueError, match="region must be a tuple of integers"):
             imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=(0, 0, 10, "invalid"))  # Type mismatch
-=======
-        try:
-            img: np.ndarray = imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition,
-                channels=["invalid_channel"],  # Invalid channel list
-            )
-        except ValueError as e:
-            assert "channels must be a list of integers" in str(e)
-
-        # 7. Test for ValueError when an invalid region tuple is provided
-        try:
-            img: np.ndarray = imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition, region=("invalid", "values", "here")
-            )
-        except ValueError as e:
-            assert "region must be a tuple of integers" in str(e)
->>>>>>> 4469fe83c1c82c75f1e112638f69d893d3905ec0
 
         # 8. Test for ValueError when region bounds are out of order
         invalid_region_2: Tuple[int, int, int, int] = (50, 50, 10, 10)  # Invalid region
@@ -179,7 +157,6 @@ class TestMCDFile:
         acquisition.metadata["DataStartOffset"] = "100"
         acquisition.metadata["DataEndOffset"] = "100"
         with pytest.warns(UserWarning, match="contains empty acquisition image data"):
-<<<<<<< HEAD
             img_empty: np.ndarray = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
             assert img_empty.shape == (5, 60, 60)
 
@@ -188,22 +165,6 @@ class TestMCDFile:
         acquisition.metadata["DataEndOffset"] = "105"  # Corrupted but will try to recover
         img_recover: np.ndarray = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, strict=False)
         assert img_recover.shape == (5, 60, 60)
-=======
-            img: np.ndarray = imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition
-            )
-            assert img.shape == (5, 60, 60)
-
-        # 12. Test for reading with `strict=False`, allowing recovery from issues
-        acquisition.metadata["DataStartOffset"] = "100"
-        acquisition.metadata["DataEndOffset"] = (
-            "105"  # Corrupted but will try to recover
-        )
-        img: np.ndarray = imc_test_data_mcd_file.read_acquisition(
-            acquisition=acquisition, strict=False
-        )
-        assert img.shape == (5, 60, 60)
->>>>>>> 4469fe83c1c82c75f1e112638f69d893d3905ec0
 
         # 13. Test for IOError when invalid data offsets are provided
         acquisition.metadata["DataStartOffset"] = "200"
@@ -217,7 +178,6 @@ class TestMCDFile:
         # Ensure a writable temp directory
         temp_dir = Path(tempfile.mkdtemp())  # Create a temporary writable directory
         try:
-<<<<<<< HEAD
             img_memmap: np.ndarray = imc_test_data_mcd_file.read_acquisition(
                 acquisition=acquisition, create_temp_file=temp_dir
             )
@@ -228,13 +188,6 @@ class TestMCDFile:
             assert not img_memmap.flags["WRITEABLE"]  # Memory-mapped arrays are read-only
         finally:
             shutil.rmtree(temp_dir)  # Cleanup the temp directory after the test'''
-=======
-            img: np.ndarray = imc_test_data_mcd_file.read_acquisition(
-                acquisition=acquisition
-            )
-        except IOError as e:
-            assert "invalid data offsets or byte size" in str(e)
->>>>>>> 4469fe83c1c82c75f1e112638f69d893d3905ec0
 
     def test_read_acquisition_empty_data(self, imc_test_data_mcd_file: MCDFile):
         slide = imc_test_data_mcd_file.slides[0]

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -132,8 +132,8 @@ class TestMCDFile:
     def test_read_acquisition_empty_data(self, imc_test_data_mcd_file: MCDFile):
         slide = imc_test_data_mcd_file.slides[0]
         acquisition = next(a for a in slide.acquisitions if a.id == 1)
-        acquisition.metadata["DataStartOffset"] = 100
-        acquisition.metadata["DataEndOffset"] = 100 
+        acquisition.metadata["DataStartOffset"] = "100"
+        acquisition.metadata["DataEndOffset"] = "100" 
         with pytest.warns(UserWarning, match="contains empty acquisition image data"):
             img = imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
             assert img.shape == (5, 60, 60)

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -135,13 +135,6 @@ class TestMCDFile:
                 acquisition=acquisition, region=invalid_region_1
             )
 
-        # Test with invalid channel names
-        #invalid_channels: Tuple[int, str, float] = [1, '2', 3.0]
-        #with pytest.raises(ValueError, match="channels must be a list of integers"):
-            #imc_test_data_mcd_file.read_acquisition(
-                #acquisition=acquisition, channels=invalid_channels
-            #)
-
         # Test for ValueError when no acquisition is provided
         with pytest.raises(ValueError, match="acquisition must be specified"):
             imc_test_data_mcd_file.read_acquisition(acquisition=None)

--- a/tests/test_mcd_file.py
+++ b/tests/test_mcd_file.py
@@ -123,19 +123,19 @@ class TestMCDFile:
 
         # Invalid `channels` (not all integers)
         with pytest.raises(ValueError, match="channels must be a list of integers"):
-            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, channels=[0, "invalid"])
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, channels=[0, "invalid"]) # type: ignore
 
         # Invalid `region` (not all integers)
         with pytest.raises(ValueError, match="region must be a tuple of integers"):
-            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=(0, 0, "50", 50))
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=(0, 0, "50", 50)) # type: ignore
 
         # Invalid `region` values
         with pytest.raises(ValueError, match="region must be \\(x_min, y_min, x_max, y_max\\)"):
             imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, region=(10, 10, 5, 50))
 
         # Invalid `create_temp_file` type
-        with pytest.raises(ValueError, match="create_temp_file must be a string or Path object."):
-            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, create_temp_file=123)
+        with pytest.raises(ValueError, match="create_temp_file must be a string or Path object."): 
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition, create_temp_file=123) # type: ignore
 
         # Missing metadata keys
         acquisition.metadata.pop("DataStartOffset", None)
@@ -147,7 +147,7 @@ class TestMCDFile:
         acquisition.metadata["DataEndOffset"] = "50"  # Invalid offset order
 
         with pytest.raises(IOError, match="MCD file corrupted: invalid data offsets or byte size"):
-            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition)
+            imc_test_data_mcd_file.read_acquisition(acquisition=acquisition) # type: ignore
 
         # Restore metadata for empty acquisition test
         acquisition.metadata["DataEndOffset"] = "100"


### PR DESCRIPTION
This PR solves two issues combined (#36, #37):

- Added functionality and tests to subset to specific channels by indexing
- Added functionality and tests to subset to specific image region
- Added functionality to load data into memory-mapped array, that is stored under a path provided by the user (so it can manually be deleted afterwards)
- Changed data_start_offset & data_end_offset conditions such that empty acquisitions are allowed (but warning printed)